### PR TITLE
Remove Organizations from profile json

### DIFF
--- a/sync.go
+++ b/sync.go
@@ -93,7 +93,6 @@ type Profile struct {
 	Key                CipherString
 	PrivateKey         CipherString
 	SecurityStamp      string
-	Organizations      []string
 }
 
 type Folder struct {


### PR DESCRIPTION
This PR removes organizations from the profile json. Organizations are not []string, they are an array of another struct. But since organizations are not used by bitw anyway, it seems pointless to model that struct.

Without this PR, a `bitw sync` for a user in an organization results in `error: could not sync: json: cannot unmarshal object into Go struct field Profile.Profile.Organizations of type string`