### PR TITLE
Fallback to api login when a captcha is required.

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -110,12 +110,11 @@ func login(ctx context.Context, useApiKey bool) error {
 		if err != nil {
 			return err
 		}
-		fmt.Printf("client_id: %s\n", string(client_id[:]))
+
 		client_secret, err := secrets.client_secret()
 		if err != nil {
 			return err
 		}
-		fmt.Printf("client_secret: %s\n", string(client_secret[:]))
 
 		values = urlValues(
 			"client_id", string(client_id[:]),

--- a/crypto.go
+++ b/crypto.go
@@ -24,10 +24,10 @@ import (
 type secretCache struct {
 	data *dataFile
 
-	_password      []byte // cached, to avoid repeated prompts
-	_configEmail   string
-	_client_id     []byte
-	_client_secret []byte
+	_password     []byte // cached, to avoid repeated prompts
+	_configEmail  string
+	_clientId     []byte
+	_clientSecret []byte
 
 	// TODO: store these more securely
 	key    []byte
@@ -62,36 +62,36 @@ func (c *secretCache) password() ([]byte, error) {
 	return c._password, nil
 }
 
-func (c *secretCache) client_id() ([]byte, error) {
-	if c._client_id != nil {
-		return c._client_id, nil
+func (c *secretCache) clientId() ([]byte, error) {
+	if c._clientId != nil {
+		return c._clientId, nil
 	}
 	if s := os.Getenv("CLIENT_ID"); s != "" {
-		c._client_id = []byte(s)
-		return c._client_id, nil
+		c._clientId = []byte(s)
+		return c._clientId, nil
 	}
-	client_id, err := passwordPrompt("client_id")
+	clientId, err := passwordPrompt("client_id")
 	if err != nil {
 		return nil, err
 	}
-	c._client_id = []byte(client_id)
-	return c._client_id, nil
+	c._clientId = []byte(clientId)
+	return c._clientId, nil
 }
 
-func (c *secretCache) client_secret() ([]byte, error) {
-	if c._client_secret != nil {
-		return c._client_secret, nil
+func (c *secretCache) clientSecret() ([]byte, error) {
+	if c._clientSecret != nil {
+		return c._clientSecret, nil
 	}
 	if s := os.Getenv("CLIENT_SECRET"); s != "" {
-		c._client_secret = []byte(s)
-		return c._client_secret, nil
+		c._clientSecret = []byte(s)
+		return c._clientSecret, nil
 	}
-	client_secret, err := passwordPrompt("client_secret")
+	clientSecret, err := passwordPrompt("client_secret")
 	if err != nil {
 		return nil, err
 	}
-	c._client_secret = []byte(client_secret)
-	return c._client_secret, nil
+	c._clientSecret = []byte(clientSecret)
+	return c._clientSecret, nil
 }
 
 func (c *secretCache) initKeys() error {

--- a/crypto.go
+++ b/crypto.go
@@ -24,8 +24,10 @@ import (
 type secretCache struct {
 	data *dataFile
 
-	_password    []byte // cached, to avoid repeated prompts
-	_configEmail string
+	_password      []byte // cached, to avoid repeated prompts
+	_configEmail   string
+	_client_id     []byte
+	_client_secret []byte
 
 	// TODO: store these more securely
 	key    []byte
@@ -58,6 +60,38 @@ func (c *secretCache) password() ([]byte, error) {
 	}
 	c._password = []byte(password)
 	return c._password, nil
+}
+
+func (c *secretCache) client_id() ([]byte, error) {
+	if c._client_id != nil {
+		return c._client_id, nil
+	}
+	if s := os.Getenv("CLIENT_ID"); s != "" {
+		c._client_id = []byte(s)
+		return c._client_id, nil
+	}
+	client_id, err := passwordPrompt("client_id")
+	if err != nil {
+		return nil, err
+	}
+	c._client_id = []byte(client_id)
+	return c._client_id, nil
+}
+
+func (c *secretCache) client_secret() ([]byte, error) {
+	if c._client_secret != nil {
+		return c._client_secret, nil
+	}
+	if s := os.Getenv("CLIENT_SECRET"); s != "" {
+		c._client_secret = []byte(s)
+		return c._client_secret, nil
+	}
+	client_secret, err := passwordPrompt("client_secret")
+	if err != nil {
+		return nil, err
+	}
+	c._client_secret = []byte(client_secret)
+	return c._client_secret, nil
 }
 
 func (c *secretCache) initKeys() error {

--- a/main.go
+++ b/main.go
@@ -267,7 +267,7 @@ func run(args ...string) (err error) {
 	ctx = context.WithValue(ctx, authToken{}, globalData.AccessToken)
 	switch args[0] {
 	case "login":
-		if err := login(ctx); err != nil {
+		if err := login(ctx, false); err != nil {
 			return err
 		}
 	case "sync":
@@ -331,7 +331,7 @@ func run(args ...string) (err error) {
 
 func ensureToken(ctx context.Context) error {
 	if globalData.RefreshToken == "" {
-		if err := login(ctx); err != nil {
+		if err := login(ctx, false); err != nil {
 			return err
 		}
 	} else if time.Now().After(globalData.TokenExpiry) {


### PR DESCRIPTION
Sometimes when a new device is used the api require the client to solve
a captcha, since is a stupid idea we ignore the captcha and we try to
login using the api key, after the first login the api should not ask
again for the captcha.

This should solve #31