### PR TITLE
Implement argon2id support

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -89,7 +89,10 @@ func login(ctx context.Context, retryWithApiKey bool) error {
 
 		// First, we create the master key, with the password, the lowercase
 		// email as salt, and the number of iterations the server told us.
-		masterKey := deriveMasterKey(password, email, preLogin.KDF, preLogin.KDFIterations, preLogin.KDFMemory, preLogin.KDFParallelism)
+		masterKey, err := deriveMasterKey(password, email, preLogin.KDF, preLogin.KDFIterations, preLogin.KDFMemory, preLogin.KDFParallelism)
+		if err != nil {
+			return err
+		}
 
 		// Then we create the hashed password, with the master key as password,
 		// the password as hash, and just one iteration.

--- a/auth.go
+++ b/auth.go
@@ -25,8 +25,10 @@ type preLoginRequest struct {
 }
 
 type preLoginResponse struct {
-	KDF           int
-	KDFIterations int
+	KDF            int
+	KDFIterations  int
+	KDFMemory      int
+	KDFParallelism int
 }
 
 type tokLoginResponse struct {
@@ -74,6 +76,8 @@ func login(ctx context.Context, retryWithApiKey bool) error {
 	}
 	globalData.KDF = preLogin.KDF
 	globalData.KDFIterations = preLogin.KDFIterations
+	globalData.KDFMemory = preLogin.KDFMemory
+	globalData.KDFParallelism = preLogin.KDFParallelism
 	saveData = true
 
 	var values url.Values
@@ -85,7 +89,7 @@ func login(ctx context.Context, retryWithApiKey bool) error {
 
 		// First, we create the master key, with the password, the lowercase
 		// email as salt, and the number of iterations the server told us.
-		masterKey := deriveMasterKey(password, email, preLogin.KDFIterations)
+		masterKey := deriveMasterKey(password, email, preLogin.KDF, preLogin.KDFIterations, preLogin.KDFMemory, preLogin.KDFParallelism)
 
 		// Then we create the hashed password, with the master key as password,
 		// the password as hash, and just one iteration.

--- a/auth.go
+++ b/auth.go
@@ -74,7 +74,7 @@ func login(ctx context.Context, retryWithApiKey bool) error {
 	}); err != nil {
 		return fmt.Errorf("could not pre-login: %v", err)
 	}
-	globalData.KDF = preLogin.KDF
+	globalData.KDF = KDFType(preLogin.KDF)
 	globalData.KDFIterations = preLogin.KDFIterations
 	globalData.KDFMemory = preLogin.KDFMemory
 	globalData.KDFParallelism = preLogin.KDFParallelism
@@ -89,7 +89,7 @@ func login(ctx context.Context, retryWithApiKey bool) error {
 
 		// First, we create the master key, with the password, the lowercase
 		// email as salt, and the number of iterations the server told us.
-		masterKey, err := deriveMasterKey(password, email, preLogin.KDF, preLogin.KDFIterations, preLogin.KDFMemory, preLogin.KDFParallelism)
+		masterKey, err := deriveMasterKey(password, email, KDFType(preLogin.KDF), preLogin.KDFIterations, preLogin.KDFMemory, preLogin.KDFParallelism)
 		if err != nil {
 			return err
 		}

--- a/crypto.go
+++ b/crypto.go
@@ -117,7 +117,10 @@ func (c *secretCache) initKeys() error {
 		return err
 	}
 
-	masterKey := deriveMasterKey(password, email, c.data.KDF, c.data.KDFIterations, c.data.KDFMemory, c.data.KDFParallelism)
+	masterKey, err := deriveMasterKey(password, email, c.data.KDF, c.data.KDFIterations, c.data.KDFMemory, c.data.KDFParallelism)
+	if err != nil {
+		return err
+	}
 
 	// This bit of code can help create a random key and encrypt it with a
 	// given email/password. Useful for creating test data for TestCipherString.
@@ -163,15 +166,15 @@ func (c *secretCache) initKeys() error {
 	return nil
 }
 
-func deriveMasterKey(password []byte, email string, kdfType int, iter int, mem int, par int) []byte {
+func deriveMasterKey(password []byte, email string, kdfType int, iter int, mem int, par int) ([]byte, error) {
 	switch kdfType {
 	case KDFTypePBKDF2:
-		return pbkdf2.Key(password, []byte(strings.ToLower(email)), iter, 32, sha256.New)
+		return pbkdf2.Key(password, []byte(strings.ToLower(email)), iter, 32, sha256.New), nil
 	case KDFTypeArgon2id:
 		var salt [32]byte = sha256.Sum256([]byte(strings.ToLower(email)))
-		return argon2.IDKey(password, salt[:], uint32(iter), uint32(mem*1024), uint8(par), 32)
+		return argon2.IDKey(password, salt[:], uint32(iter), uint32(mem*1024), uint8(par), 32), nil
 	default:
-		return pbkdf2.Key(password, []byte(strings.ToLower(email)), iter, 32, sha256.New)
+		return nil, fmt.Errorf("unsupported KDF type %d", kdfType)
 	}
 }
 

--- a/crypto.go
+++ b/crypto.go
@@ -22,9 +22,11 @@ import (
 	"golang.org/x/crypto/pbkdf2"
 )
 
+type KDFType int
+
 const (
-	KDFTypePBKDF2   = 0
-	KDFTypeArgon2id = 1
+	KDFTypePBKDF2   KDFType = 0
+	KDFTypeArgon2id KDFType = 1
 )
 
 type secretCache struct {
@@ -166,7 +168,7 @@ func (c *secretCache) initKeys() error {
 	return nil
 }
 
-func deriveMasterKey(password []byte, email string, kdfType int, iter int, mem int, par int) ([]byte, error) {
+func deriveMasterKey(password []byte, email string, kdfType KDFType, iter int, mem int, par int) ([]byte, error) {
 	switch kdfType {
 	case KDFTypePBKDF2:
 		return pbkdf2.Key(password, []byte(strings.ToLower(email)), iter, 32, sha256.New), nil

--- a/crypto.go
+++ b/crypto.go
@@ -17,8 +17,14 @@ import (
 	"os"
 	"strings"
 
+	"golang.org/x/crypto/argon2"
 	"golang.org/x/crypto/hkdf"
 	"golang.org/x/crypto/pbkdf2"
+)
+
+const (
+	KDFTypePBKDF2   = 0
+	KDFTypeArgon2id = 1
 )
 
 type secretCache struct {
@@ -111,7 +117,7 @@ func (c *secretCache) initKeys() error {
 		return err
 	}
 
-	masterKey := deriveMasterKey(password, email, c.data.KDFIterations)
+	masterKey := deriveMasterKey(password, email, c.data.KDF, c.data.KDFIterations, c.data.KDFMemory, c.data.KDFParallelism)
 
 	// This bit of code can help create a random key and encrypt it with a
 	// given email/password. Useful for creating test data for TestCipherString.
@@ -157,8 +163,16 @@ func (c *secretCache) initKeys() error {
 	return nil
 }
 
-func deriveMasterKey(password []byte, email string, iter int) []byte {
-	return pbkdf2.Key(password, []byte(strings.ToLower(email)), iter, 32, sha256.New)
+func deriveMasterKey(password []byte, email string, kdfType int, iter int, mem int, par int) []byte {
+	switch kdfType {
+	case KDFTypePBKDF2:
+		return pbkdf2.Key(password, []byte(strings.ToLower(email)), iter, 32, sha256.New)
+	case KDFTypeArgon2id:
+		var salt [32]byte = sha256.Sum256([]byte(strings.ToLower(email)))
+		return argon2.IDKey(password, salt[:], uint32(iter), uint32(mem*1024), uint8(par), 32)
+	default:
+		return pbkdf2.Key(password, []byte(strings.ToLower(email)), iter, 32, sha256.New)
+	}
 }
 
 func stretchKey(orig []byte) (key, macKey []byte) {

--- a/main.go
+++ b/main.go
@@ -130,12 +130,14 @@ func init() { secrets.data = &globalData }
 type dataFile struct {
 	path string
 
-	DeviceID      string
-	AccessToken   string
-	RefreshToken  string
-	TokenExpiry   time.Time
-	KDF           int
-	KDFIterations int
+	DeviceID       string
+	AccessToken    string
+	RefreshToken   string
+	TokenExpiry    time.Time
+	KDF            int
+	KDFIterations  int
+	KDFMemory      int
+	KDFParallelism int
 
 	LastSync time.Time
 	Sync     SyncData

--- a/main.go
+++ b/main.go
@@ -134,7 +134,7 @@ type dataFile struct {
 	AccessToken    string
 	RefreshToken   string
 	TokenExpiry    time.Time
-	KDF            int
+	KDF            KDFType
 	KDFIterations  int
 	KDFMemory      int
 	KDFParallelism int


### PR DESCRIPTION
Hi,

argon2 KDF support has been implemented in the official clients and server now. This PR adds support to bitw, to be able to log in when argon2 is selected as the user's KDF. 

The prelogin response now has 2 optional parameters, kdfMemory and kdfParallelism. The KDF value which previously was always 0, can now also be 1 for argon2id. To derive the master key, the email has to be sha256 hashed, and the memory value is converted from MiB to KiB.

As far as I know, Go has no builtin for optionals, so for now the optional parameters would just be set to "0". Let me know if I should use an optional library or some other approach instead.