### PR TITLE
Make dump fast by skipping initKeys() when keys are already present

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -95,6 +95,10 @@ func (c *secretCache) clientSecret() ([]byte, error) {
 }
 
 func (c *secretCache) initKeys() error {
+	if c.key != nil {
+		return nil
+	}
+
 	keyCipher := c.data.Sync.Profile.Key
 	switch keyCipher.Type {
 	case AesCbc256_B64, AesCbc256_HmacSha256_B64:


### PR DESCRIPTION
Right now, when running dump, initKeys gets called up to four times (Name, URI, Username, Password) for each login cipher in the vault. InitKeys then derives the master key, which means a call to the KDF, which can take a second and more, especially with argon2 or the newer higher PBKDF2 iteration counts. 

This leads to entries only very slowly appearing one after another when running dump. My main vault would take > 1 hour to decrypt this way.

This PR skips the key init, when the keys are already present. This makes running dump pretty much instantaneous, even with a slow argon2 configuration.