### PR TITLE
Fix broken login due to webauthn

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -174,7 +174,8 @@ const (
 	U2f                   TwoFactorProvider = 4
 	Remember              TwoFactorProvider = 5
 	OrganizationDuo       TwoFactorProvider = 6
-	_TwoFactorProviderMax                   = 7
+	WebAuthn              TwoFactorProvider = 7
+	_TwoFactorProviderMax                   = 8
 )
 
 func (t *TwoFactorProvider) UnmarshalText(text []byte) error {


### PR DESCRIPTION
Having webauthn (method 7) as one of the 2fa methods on your account prevents login, since while parsing, this line:

`if err != nil || i < 0 || i >= _TwoFactorProviderMax {` 
ensures that the methods are all below 7. Even if you have other 2fa methods configured, you do not get to choose them.

This commit does not implement webauthn login, but does fix broken login when webauthn is one of the methods on the account, by letting you choose the other methods.

This partially fixes #38 