### PR TITLE
Fix crash when organization ciphers are used

### DIFF
--- a/main.go
+++ b/main.go
@@ -306,6 +306,11 @@ func run(args ...string) (err error) {
 				cipher.Login.Username,
 				cipher.Login.Password,
 			} {
+				// Organization ciphers are not supported for now
+				if cipher.OrganizationID != nil {
+					continue
+				}
+
 				s, err := secrets.decrypt(cipherStr)
 				if err != nil {
 					return err


### PR DESCRIPTION
The cryptographic routines for organization are not yet implemented. This leads to a crash when organization owned ciphers are decrypted. Until organizations are properly implemented, this PR fixes the crash by skipping organization entries.

This makes dump correctly decrypt all non-organization ciphers in the vault, the organization entries are skipped.

Related issue is #19 