### PR TITLE
Add organization support

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -48,6 +48,7 @@ type secretCache struct {
 	macKey []byte
 
 	// should we also store this as bytes and then decode on every use?
+	// TODO: also store these more securely, like above
 	privateKey *rsa.PrivateKey
 	orgKeys    map[string][]byte
 	orgMacKeys map[string][]byte

--- a/crypto.go
+++ b/crypto.go
@@ -192,21 +192,20 @@ func (c *secretCache) initKeys() error {
 	c.orgMacKeys = make(map[string][]byte)
 
 	for _, organization := range c.data.Sync.Profile.Organizations {
-		fmt.Println(organization)
-
+		// the first byte is the encryption type (always 4 at the moment)
+		// the second byte is a separator
 		var keyString = organization.Key[2:]
 
-		//base64 decode key
 		decodedData, err := base64.StdEncoding.DecodeString(keyString)
-
 		if err != nil {
 			return err
 		}
+
 		res, err := rsa.DecryptOAEP(sha1.New(), rand.Reader, c.privateKey, decodedData, nil)
-
 		if err != nil {
 			return err
 		}
+
 		c.orgKeys[organization.Id.String()] = res[0:32]
 		c.orgMacKeys[organization.Id.String()] = res[32:64]
 	}

--- a/dbus.go
+++ b/dbus.go
@@ -147,7 +147,15 @@ func (d *dbusService) secretByPath(item, session dbus.ObjectPath) (secret dbusSe
 		return secret, errNoSuchObject
 	}
 
-	password, err := secrets.decrypt(cipher.Login.Password)
+	var password []byte
+	var err error
+
+	if cipher.OrganizationID == nil {
+		password, err = secrets.decrypt(cipher.Login.Password)
+	} else {
+		password, err = decryptWith(cipher.Login.Password, secrets.orgKeys[cipher.OrganizationID.String()], secrets.orgMacKeys[cipher.OrganizationID.String()])
+	}
+
 	if err != nil {
 		return secret, dbusErrorf("%s", err)
 	}

--- a/dbus.go
+++ b/dbus.go
@@ -150,12 +150,7 @@ func (d *dbusService) secretByPath(item, session dbus.ObjectPath) (secret dbusSe
 	var password []byte
 	var err error
 
-	if cipher.OrganizationID == nil {
-		password, err = secrets.decrypt(cipher.Login.Password)
-	} else {
-		password, err = decryptWith(cipher.Login.Password, secrets.orgKeys[cipher.OrganizationID.String()], secrets.orgMacKeys[cipher.OrganizationID.String()])
-	}
-
+	password, err = secrets.decrypt(cipher.Login.Password, cipher.OrganizationID)
 	if err != nil {
 		return secret, dbusErrorf("%s", err)
 	}

--- a/main.go
+++ b/main.go
@@ -308,7 +308,19 @@ func run(args ...string) (err error) {
 				cipher.Login.Username,
 				cipher.Login.Password,
 			} {
-				s, err := secrets.decrypt(cipherStr)
+				if cipherStr.IsZero() {
+					continue
+				}
+
+				var s []byte
+				var err error
+
+				if cipher.OrganizationID != nil {
+					s, err = decryptWith(cipherStr, secrets.orgKeys[cipher.OrganizationID.String()], secrets.orgMacKeys[cipher.OrganizationID.String()])
+				} else {
+					s, err = secrets.decrypt(cipherStr)
+				}
+
 				if err != nil {
 					return err
 				}

--- a/main.go
+++ b/main.go
@@ -315,11 +315,7 @@ func run(args ...string) (err error) {
 				var s []byte
 				var err error
 
-				if cipher.OrganizationID != nil {
-					s, err = decryptWith(cipherStr, secrets.orgKeys[cipher.OrganizationID.String()], secrets.orgMacKeys[cipher.OrganizationID.String()])
-				} else {
-					s, err = secrets.decrypt(cipherStr)
-				}
+				s, err = secrets.decrypt(cipherStr, cipher.OrganizationID)
 
 				if err != nil {
 					return err

--- a/main_test.go
+++ b/main_test.go
@@ -258,7 +258,7 @@ func TestCipherString(t *testing.T) {
 			qt.Check(t, err, qt.IsNil)
 
 			// Decrypt it, and ensure we get the same plaintext.
-			gotPlain, err := secrets.decrypt(inputCipher)
+			gotPlain, err := secrets.decrypt(inputCipher, nil)
 			qt.Check(t, err, qt.IsNil)
 			qt.Check(t, string(gotPlain), qt.Equals, test.want)
 
@@ -270,7 +270,7 @@ func TestCipherString(t *testing.T) {
 			// Decrypt the cipher string we encrypted, to check that
 			// we still get the same plaintext. This ensures the
 			// full roundtrip works.
-			gotPlain, err = secrets.decrypt(gotCipher)
+			gotPlain, err = secrets.decrypt(gotCipher, nil)
 			qt.Check(t, err, qt.IsNil)
 			qt.Check(t, string(gotPlain), qt.Equals, test.want)
 		})

--- a/sync.go
+++ b/sync.go
@@ -241,9 +241,9 @@ func (c *Cipher) Match(attr, value string) bool {
 	case "id":
 		got = c.ID.String()
 	case "name":
-		got, err = secrets.decryptStr(c.Name)
+		got, err = secrets.decryptStr(c.Name, c.OrganizationID)
 	case "username":
-		got, err = secrets.decryptStr(c.Login.Username)
+		got, err = secrets.decryptStr(c.Login.Username, c.OrganizationID)
 	default:
 		return false
 	}

--- a/testdata/data-notfa.json
+++ b/testdata/data-notfa.json
@@ -1,11 +1,13 @@
 {
-	"DeviceID": "cfd6811f-7f66-4393-bbdf-4d509ae4904b",
-	"AccessToken": "eyJhbGciOiJSUzI1NiIsImtpZCI6IkJDMzZDMjE0REI0OEYyMzVCNzdEQTNGMTcyMEMxQTM1QTk2MkVBNDMiLCJ0eXAiOiJKV1QiLCJ4NXQiOiJ2RGJDRk50SThqVzNmYVB4Y2d3YU5hbGk2a00ifQ.eyJuYmYiOjE1NzQ1MjUyNTYsImV4cCI6MTU3NDYxMTY1NiwiaXNzIjoiaHR0cHM6Ly9pZGVudGl0eS5iaXR3YXJkZW4uY29tIiwiYXVkIjpbImh0dHBzOi8vaWRlbnRpdHkuYml0d2FyZGVuLmNvbS9yZXNvdXJjZXMiLCJhcGkiXSwiY2xpZW50X2lkIjoiY29ubmVjdG9yIiwic3ViIjoiNjZiNTQzNTItZDMxMS00ODY2LTkwY2ItYWE2ZDAwZDYyZjNiIiwiYXV0aF90aW1lIjoxNTc0NTI1MjU2LCJpZHAiOiJiaXR3YXJkZW4iLCJwcmVtaXVtIjpmYWxzZSwiZW1haWwiOiJ0ZXN0bm90ZmFAbXZkYW4uY2MiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwic3N0YW1wIjoiRUFDWldRTEZaQUw2WFZZQzcyRVZJUUNWRFNOSU8yMlEiLCJuYW1lIjoiVGVzdCBXaXRob3V0IFRGQSIsImRldmljZSI6ImNmZDY4MTFmLTdmNjYtNDM5My1iYmRmLTRkNTA5YWU0OTA0YiIsInNjb3BlIjpbImFwaSIsIm9mZmxpbmVfYWNjZXNzIl0sImFtciI6WyJBcHBsaWNhdGlvbiJdfQ.hD_GispEQwrzZAk0Sjz_Mnmt1NKAoWI49xyS9NimiYxgR3c8cDgaysHWsZzF6igWbhq_7rbhPqacQKn7TAmVh1OeBUy7fx0pIvUji_tGAvZPxs_88Mt-H-TjfqsFUNQme6pKSBsRl_vZpJqACn5URZ-9kEK0VD7jsJ_tEXhi1H7nGZdw4fagbnbPnYMbNbtbIovBVUeScfkrI4n-ijahO-tcOSd7EeEF0EjlHm4CVyHTr1grXctySYw-riWV4SFuj0atbGFV_-sd52qvi6DFlRvEAovp1FbYOrGk1GbdBU7iHxgIeXZHq-KzffiNcwb92QtaeQrfrbGDbHHf7Q9EgE3XltItSUWY-K_acZEmGJxALTOaQatbf42cW1RdmytolslgQoifttZJtLqYCWWRY3W3_54XAge7PSvAVyyJPsKy0K_eTQfirTZ49C1Zc_dAcssZGVlnzxjoH63V8gDrc8xxFFXKqVHdi5GvYopSJ492uccZDGieflqTU_KDn72UkRX5AnXLdeRxmqqnF5pXJm0z83IAONsWbQC_izKddz1LBoocpaNpgLb86hBTF0ZBvAf6noQ-U1cMLUmsOjwvm6MOAHOdPkNnb3CQY2GZ_KNTE0hK2gYy7YnvIGbQczdjOh0xi2BtNGg3CaTXyQJss_xjaYDkGslHUSjlvA4Vthk",
-	"RefreshToken": "39f1745963b488ac8eb84c5ad24c52949cd3349aacf449c637f4d753f6c73fe8",
-	"TokenExpiry": "2019-11-24T16:07:36.128187261Z",
+	"DeviceID": "26e3382c-9d12-4713-9193-b7e803f7ceca",
+	"AccessToken": "REDACTED",
+	"RefreshToken": "REDACTED",
+	"TokenExpiry": "2023-03-24T22:16:58.265147512Z",
 	"KDF": 0,
 	"KDFIterations": 100000,
-	"LastSync": "2019-11-23T16:07:36.888239305Z",
+	"KDFMemory": 0,
+	"KDFParallelism": 0,
+	"LastSync": "2023-03-23T22:17:01.786502246Z",
 	"Sync": {
 		"Profile": {
 			"ID": "66b54352-d311-4866-90cb-aa6d00d62f3b",
@@ -19,53 +21,56 @@
 			"Key": "2.lbOw26w1a0GINKkT2YAf+g==|a4NLBjU/yZhD2yAMG5f1p0aDuLVKZ5dErQZHFxP4HPLA9039hzOs2Si0FfaFN4dnUWf5FwmAml1WeO6dH5kOcL0bXm1E2T0tkNyrtQHwnpk=|3k3Os0LCQw1ekU6ZCCfUI/9ubMibVU4rGERyvKuFy1s=",
 			"PrivateKey": "2.bkIIb5bUGazvNHoA05Nrxw==|LclXYQwigrMxzTfq/kY5bNY+fE4IiumMC2H3H5R7UkDPxo1w2jaV31xSYRhpP0nkjs/eOKQhMl0nG/g6Q45QB32hItLxL+vMd4vzSz+xP6BcxGw7lCOUPtLqlBD0WycLnlMIZwj/6AxxCNgB+fcUgUWXgUQ6BLfytNT/nqsW3qiyIfYblUv4z1EvsJMPG0iGOuhggN9eWSHsv6vAodsITh4l6OszXnXUBBAPrvrT4ZakEfU7YiztLd6mycdvNDvS9SqTFfr14DpyM42qtgvsCykkWwa9tKAsfdxdSuEjrAA6DbBzEI1Zl3h0dN6RHMCn5WiYxOvVY0HZDwLh6oi0yDAud99mz/9yvlqZr0MxbcXhXjs9f3YKzm+1j2hkwx65PAibH7+np0Kew5FeQcgPUIYmO7ezWv1QDux15V6HwY0t7tlL0N+0d8XPL4YMOPT1d0PI/7Inrmi3nZRffBotE4cx80nb83jE6BnAKst7yD7Fi2LHcQapnnoQQmVccHxIcAIQyXqHghGJTt0EFoIuF0Vsj+AxV8JMxUszuz3jEatYo0k/wZkkD++D2xExIzZ6slfVfyPH5L/xCAeFxJshn0n63JErafWYvW065pkCPgtLVC5vPWd+dG9pLqviK+aHjxKXejdzOB/IWenHeUvpG5HOLwrzDqdREbJdwkCIvmLR5CRTQQq4KhtfYG1/v12XS/ckpF+lX/Fh/reiAm47YDCD10EWFArnqTJFtYa0TJURwlmmpvomIRavZaST+IG1GJvJ4QFX2wf7JC/c8Nby/BGRMC8T5GrP8knqK+FS7K3o61zFEedKPoOuSn4WPAaTN5tS3qe9tJEo+p81hxWJwcQhnKBbRI9jKRUiDE9PwfMcXILFf/csghqlrjiZBTRO7659JpqBuXj1+kUzHVvNrBfRJUr9pt1lMhZgMNDF0inz3+BmsGvW7OH/pR4J6P+sH7kmg3KjL9zozvdl6l9Rv4J0Hjpjo0SUa8JlMUDs294bWAlaBgpMDU/U2O0r/LxeItPo1q24RO1NFVnELCJ2ucpPYxIUVvtKOwCFpZAlS5PI+zvbwpqsC34UgWmP8B22yFYmXmK+6j+LURKhYBFXkY/VdoIQrwG071YXZJuh/yjhTBnRM58GZ69KqIdDDcEqXTIYJ8Bu2kshHyZ/gS7jZlqao1+a6VpC1IWfM8MKeRuGndWBOXs8p4/TWREudVZrb+qDmdkw6HcaGatjbF1BI6fASBETEQEMLo/HmU/RPuFjbLAXuylHDXrrVXIeGwbSdwrcDlPpyO/87z79ONXioTua6aqqATdrczWteFSEmDhcMZsipYXDxkI3Dvz10dvEzYNaeRwh74bCF7jPvzrIldOEGzpLXNxEHDOqKPUKd5poKS3QaDtnl+jbvfYlFFbVJV0V1pnTHe8qycIyOWyRO4ptzG9jbp4y9GEaGdgx5HdDDW1m4Rq4uMx4OXRj7HVn/RrXnKRhDNYUkXLEy5aYF4DVsWPB7MHoYTpyoB8D4HtGsOGdQm+fno96afrbJH8NnAjJzNkq47UxgP+Q6hgXM4cIrfu8lmMZuayzLLXTHs5Ez+6JIZJuU//B9XU08591XoZ76wt7frh92GUHRdsddoRMa4bD/t26Hn2cWjFCMoM=|gwvo3FZ43g7hB3BV4Q14bASKNm/oqe4zyzKQ/Z+KfY8=",
 			"SecurityStamp": "EACZWQLFZAL6XVYC72EVIQCVDSNIO22Q",
-			"Organizations": []
+			"Organizations": [
+				{
+					"Object": "profileOrganization",
+					"Id": "47d0c1b0-e610-4185-bab3-afce016b09d9",
+					"Name": "TestOrganization",
+					"UseGroups": false,
+					"UseDirectory": false,
+					"UseEvents": false,
+					"UseTotp": false,
+					"Use2fa": false,
+					"UseApi": false,
+					"UsersGetPremium": false,
+					"SelfHost": false,
+					"Seats": 2,
+					"MaxCollections": 2,
+					"MaxStorageGb": 0,
+					"Key": "4.IqbNiEWH0r+pmoVcXLNEJK6TaWHB+y84cAztvzHd+zz4JsLpaPIcgMiWNonuIIeBFuWXn2OscimOe8VgFeRaOvBvu8tp1jTx26HVYtIHhg9NF40Y3HljrukcdzyE7FKSdlVCVL9vwZrSQfxKpkMnlUvl+6tG81BzcTa8ZVMac89yl8SRIavAlCDUeuUbpuFChxd0o8Q7CJo3MlynBV/ssCY5nb3efte66Ex32XWgxKBmBMgNIn3uE1EQn27EHhcSzbHgAJgm3qeIJlYDkWYgI2+twbqKcAG52lriIyVuZe1MW58BB4qiLeZNKgvnRT1N+/fZgLii7vD90P0+vA5Ftw==",
+					"Status": 2,
+					"Type": 0,
+					"Enabled": true
+				}
+			]
 		},
 		"Folders": [],
 		"Ciphers": [
 			{
 				"Type": 1,
-				"FolderID": "00000000-0000-0000-0000-000000000000",
-				"OrganizationID": "00000000-0000-0000-0000-000000000000",
-				"Favorite": false,
+				"ID": "85f364f5-d9ae-409d-b40f-afce016b24fb",
+				"Name": "2.GHkgnGeUyOWr6o2m7h1uoA==|R1AdnMuFKjiau2NBXKRxivc0wzTNwR9CBeApfvR7/Vw=|26YwmyFeeVQuOcxjzNPo0gef3NqMd+uTqecud8TcjUI=",
 				"Edit": true,
+				"RevisionDate": "2023-03-23T22:02:10.11Z",
+				"OrganizationID": "47d0c1b0-e610-4185-bab3-afce016b09d9",
+				"CollectionIDs": [
+					"10a4e586-012f-411e-8f38-afce016b09e1"
+				],
+				"Login": {
+					"Password": "2.xDQGUUKIy2OXxlVdLMx6HA==|ZJM5lEOeltds1vCXnxqchA==|dV9dxfSHroTk06K9RsZxPbARam/uZjTC+7Bje0vBDCs=",
+					"URI": "",
+					"URIs": null,
+					"Username": "2.KJXAj/ANaJWnY18cXLUNwQ==|Rwls1rtMVroTLnQNK+l4aQ==|1zUVEV9IjUjclTofP6JQlBoGHF6VhLbbTaKgv6lgNAE="
+				}
+			},
+			{
+				"Type": 1,
 				"ID": "e774c52d-aebb-4c40-aae7-aa6d00f13011",
-				"Attachments": null,
-				"OrganizationUseTotp": false,
+				"Name": "2.EPAQPhGICOCDgpmA5PNkZA==|GOqIw8a3A2qHwahbk/2f6Q==|6Dz7w5J+hMCASoC7EBhE1r4gw7smeqW+mKzpdPcsSMU=",
+				"Edit": true,
 				"RevisionDate": "2019-06-15T14:38:08.2666667Z",
-				"CollectionIDs": [],
-				"Card": {
-					"CardholderName": "",
-					"Brand": "",
-					"Number": "",
-					"ExpMonth": "",
-					"ExpYear": "",
-					"Code": ""
-				},
-				"Fields": null,
-				"Identity": {
-					"Title": "",
-					"FirstName": "",
-					"MiddleName": "",
-					"LastName": "",
-					"Username": "",
-					"Company": "",
-					"SSN": "",
-					"PassportNumber": "",
-					"LicenseNumber": "",
-					"Email": "",
-					"Phone": "",
-					"Address1": "",
-					"Address2": "",
-					"Address3": "",
-					"City": "",
-					"State": "",
-					"PostalCode": "",
-					"Country": ""
-				},
 				"Login": {
 					"Password": "2.vJw50ZK539wgS5bBGBbFhQ==|2Ot7gsdzT4JQ2Eil3tIq6w==|qEpYEmLuYDwFG1ICWfuPXEMyUt5Trek2nIeqPcdv/jA=",
-					"Totp": "",
 					"URI": "2.lcaNox+8VwaU+Fhzs/jcoA==|Rc+uMIvqeSFNxyKBYZIDFg==|21OosNy2eqeVpMYzkQwEMe1I27TKCFg71g7NeHP2gPI=",
 					"URIs": [
 						{
@@ -74,85 +79,27 @@
 						}
 					],
 					"Username": "2.E8pxXdTg60mDe/WdpXzIhg==|F3/3y/f8QHW5ghvnCNR+iA==|WVoohoY2f7RPzj6ocLWoKigubXmi4yys+weE0/iXFjM="
-				},
-				"Name": "2.EPAQPhGICOCDgpmA5PNkZA==|GOqIw8a3A2qHwahbk/2f6Q==|6Dz7w5J+hMCASoC7EBhE1r4gw7smeqW+mKzpdPcsSMU=",
-				"Notes": "",
-				"SecureNote": {
-					"Type": 0
 				}
 			},
 			{
 				"Type": 1,
-				"FolderID": "00000000-0000-0000-0000-000000000000",
-				"OrganizationID": "00000000-0000-0000-0000-000000000000",
-				"Favorite": false,
-				"Edit": true,
 				"ID": "55626dc4-7c07-4506-9eaf-aa76009892d4",
-				"Attachments": null,
-				"OrganizationUseTotp": false,
+				"Name": "2.HC687j/6rorSDXD3SXoqbg==|0n2JQr/BHgzB2tn2pAVWyQ==|0W/+jX/uWRFtyWD7a6sIuXPmMDhJxefF1x1I7F9qmKU=",
+				"Edit": true,
 				"RevisionDate": "2019-06-24T09:15:30.1966667Z",
-				"CollectionIDs": [],
-				"Card": {
-					"CardholderName": "",
-					"Brand": "",
-					"Number": "",
-					"ExpMonth": "",
-					"ExpYear": "",
-					"Code": ""
-				},
-				"Fields": null,
-				"Identity": {
-					"Title": "",
-					"FirstName": "",
-					"MiddleName": "",
-					"LastName": "",
-					"Username": "",
-					"Company": "",
-					"SSN": "",
-					"PassportNumber": "",
-					"LicenseNumber": "",
-					"Email": "",
-					"Phone": "",
-					"Address1": "",
-					"Address2": "",
-					"Address3": "",
-					"City": "",
-					"State": "",
-					"PostalCode": "",
-					"Country": ""
-				},
 				"Login": {
 					"Password": "2.Xt7QiBtz4U9i4B4La/vahA==|oEctJAIwsrxtPCSSsoAO7g==|tnVGxFb5CBnfJBVMtb7xoGVDub3w3CBhcl7Nj4iDHz8=",
-					"Totp": "",
 					"URI": "",
 					"URIs": null,
 					"Username": ""
-				},
-				"Name": "2.HC687j/6rorSDXD3SXoqbg==|0n2JQr/BHgzB2tn2pAVWyQ==|0W/+jX/uWRFtyWD7a6sIuXPmMDhJxefF1x1I7F9qmKU=",
-				"Notes": "",
-				"SecureNote": {
-					"Type": 0
 				}
 			},
 			{
 				"Type": 1,
-				"FolderID": "00000000-0000-0000-0000-000000000000",
-				"OrganizationID": "00000000-0000-0000-0000-000000000000",
-				"Favorite": false,
-				"Edit": true,
 				"ID": "a389bbb8-3084-4c81-8da3-aa770093ddef",
-				"Attachments": null,
-				"OrganizationUseTotp": false,
+				"Name": "2.G76KcMuYko/MvrPNcJDOrg==|iOaLA6yYAq4r1Hzzef5jBA==|yAskzd7Y+DCLdz0VoN+KLHkzbzQo+vk/m5+QobFj0u0=",
+				"Edit": true,
 				"RevisionDate": "2019-06-25T08:58:22.02Z",
-				"CollectionIDs": [],
-				"Card": {
-					"CardholderName": "",
-					"Brand": "",
-					"Number": "",
-					"ExpMonth": "",
-					"ExpYear": "",
-					"Code": ""
-				},
 				"Fields": [
 					{
 						"Type": 0,
@@ -170,29 +117,8 @@
 						"Value": "2.0sq9ED3FaU0Ecb5StQrfdQ==|fnjYdvOACh48WmVnZs8Xhw==|6BqCIzhVg3MRkMjqIoxaGUvQlXFMzh23CJCWEJWjAK8="
 					}
 				],
-				"Identity": {
-					"Title": "",
-					"FirstName": "",
-					"MiddleName": "",
-					"LastName": "",
-					"Username": "",
-					"Company": "",
-					"SSN": "",
-					"PassportNumber": "",
-					"LicenseNumber": "",
-					"Email": "",
-					"Phone": "",
-					"Address1": "",
-					"Address2": "",
-					"Address3": "",
-					"City": "",
-					"State": "",
-					"PostalCode": "",
-					"Country": ""
-				},
 				"Login": {
 					"Password": "2.L/MbjQnlx+okG2vyyZbxiQ==|B0lXBLlqnwaNJXTBxJn5RA==|uRoedMgMKi9oHlZjfAC3g06xRnK9aDSexwG8HmXZkmw=",
-					"Totp": "2.f3cNwdUgCyUUldtfC1d82w==|sxSLQWxYB/IulJFs5tz+9w==|+KfGc7O7DY9MiBq1/M6X519qnsBOEypPzrt/7CbL1CQ=",
 					"URI": "2.xTGVUo3r45C+TncBtgkCHQ==|hL+ArexWfvAv0raDva512w==|vXWz/XYWIo/wX4WkyPfLlP7yO1neqFj5eRNvkyYKzvw=",
 					"URIs": [
 						{
@@ -204,25 +130,17 @@
 							"Match": 0
 						}
 					],
-					"Username": "2.iHzprFGKe8sIe+dRCVlEAg==|4w5/OU5Yv8pqzRBzTcdFgg==|D7Hw5PL1ef7kHAg7FKKYVJH0FZpFktSvlzaiRH2fd+A="
+					"Username": "2.iHzprFGKe8sIe+dRCVlEAg==|4w5/OU5Yv8pqzRBzTcdFgg==|D7Hw5PL1ef7kHAg7FKKYVJH0FZpFktSvlzaiRH2fd+A=",
+					"Totp": "2.f3cNwdUgCyUUldtfC1d82w==|sxSLQWxYB/IulJFs5tz+9w==|+KfGc7O7DY9MiBq1/M6X519qnsBOEypPzrt/7CbL1CQ="
 				},
-				"Name": "2.G76KcMuYko/MvrPNcJDOrg==|iOaLA6yYAq4r1Hzzef5jBA==|yAskzd7Y+DCLdz0VoN+KLHkzbzQo+vk/m5+QobFj0u0=",
-				"Notes": "2.klNkT2BneCf6Rxf0xEKlRw==|oFpB4ZMJ7sSDMB8NE0lB3Q==|xcEnADo7NIIX3CEyTjd0naTBTVdXOZPo/oualkRkJWI=",
-				"SecureNote": {
-					"Type": 0
-				}
+				"Notes": "2.klNkT2BneCf6Rxf0xEKlRw==|oFpB4ZMJ7sSDMB8NE0lB3Q==|xcEnADo7NIIX3CEyTjd0naTBTVdXOZPo/oualkRkJWI="
 			},
 			{
 				"Type": 3,
-				"FolderID": "00000000-0000-0000-0000-000000000000",
-				"OrganizationID": "00000000-0000-0000-0000-000000000000",
-				"Favorite": false,
-				"Edit": true,
 				"ID": "7b34b71b-833b-4089-acad-ab0e00f39513",
-				"Attachments": null,
-				"OrganizationUseTotp": false,
+				"Name": "2.Mzb8YdUm+GPkqr03t+O1kw==|2J/a1D3G4jhp/cWcSUoglg==|wJh97w7ZnSCSDmLcKqIQfkK2SW4XnSxiy9u5Rn5G5JE=",
+				"Edit": true,
 				"RevisionDate": "2019-11-23T14:46:51.3666667Z",
-				"CollectionIDs": [],
 				"Card": {
 					"CardholderName": "2.Tj1CPqkaxd+uzAxASU5ugg==|Q9gL0PV+g7THK2ECo3eUbA==|W3yBmhyDiI1rCBTgefm9n2ZOqRiXjRkSGKvLur7RQ/U=",
 					"Brand": "2.R/XSt0eNPhY5M+Etf6UFJg==|pSzVrbbseJKZ1l406BwBKQ==|5rN27I/PWBc7uIblvIvZhRdLKpRa5FTkzlh2LRXRjF4=",
@@ -230,61 +148,14 @@
 					"ExpMonth": "2.8cs8y4L6JwnZJJzE7H3NQA==|Xw/mCaqcKVZyZ8IlFC4Ewg==|9oJLixcjqce1VrJmhLSsTW684EfcM8IO5lj87GqxMcE=",
 					"ExpYear": "2.Ggj8QEf5reuxQ5WIOyrLHw==|zYrZN+w+oTTPgggU6FyV5g==|nLr23X59gVcoLr/hEwTx0GaA2J53V5IN2JjPMcwM6n4=",
 					"Code": "2.tjXx42hRF00sbWhKsd3egg==|zMAZyJzREVIz2ydSiM+pXA==|CZAcaDNtSGYiVqZ19G7wx5ym3EcoZRioIYLwhD6EJ6c="
-				},
-				"Fields": null,
-				"Identity": {
-					"Title": "",
-					"FirstName": "",
-					"MiddleName": "",
-					"LastName": "",
-					"Username": "",
-					"Company": "",
-					"SSN": "",
-					"PassportNumber": "",
-					"LicenseNumber": "",
-					"Email": "",
-					"Phone": "",
-					"Address1": "",
-					"Address2": "",
-					"Address3": "",
-					"City": "",
-					"State": "",
-					"PostalCode": "",
-					"Country": ""
-				},
-				"Login": {
-					"Password": "",
-					"Totp": "",
-					"URI": "",
-					"URIs": null,
-					"Username": ""
-				},
-				"Name": "2.Mzb8YdUm+GPkqr03t+O1kw==|2J/a1D3G4jhp/cWcSUoglg==|wJh97w7ZnSCSDmLcKqIQfkK2SW4XnSxiy9u5Rn5G5JE=",
-				"Notes": "",
-				"SecureNote": {
-					"Type": 0
 				}
 			},
 			{
 				"Type": 4,
-				"FolderID": "00000000-0000-0000-0000-000000000000",
-				"OrganizationID": "00000000-0000-0000-0000-000000000000",
-				"Favorite": false,
-				"Edit": true,
 				"ID": "f75f972a-d5e2-41db-bca8-ab0e00f4166c",
-				"Attachments": null,
-				"OrganizationUseTotp": false,
+				"Name": "2.wjf68OX0MD94JKVin5R5pQ==|VVZczGNLYFA3mZWKipMTMw==|QXn4bDphnWGBLDZSNvlaiMAtlRiC+TecePmrNCI0gFY=",
+				"Edit": true,
 				"RevisionDate": "2019-11-23T14:48:41.7433333Z",
-				"CollectionIDs": [],
-				"Card": {
-					"CardholderName": "",
-					"Brand": "",
-					"Number": "",
-					"ExpMonth": "",
-					"ExpYear": "",
-					"Code": ""
-				},
-				"Fields": null,
 				"Identity": {
 					"Title": "2.V1EUVQJP56gIZy2MDx01yA==|0pJnDDzlUlOxagbDjcGzsw==|HZWjqKJJ6lA6yHxCNKkVDGcrVuoVaho3CNZWnRT9GDc=",
 					"FirstName": "2.KrWQQozVNdvvuSvexhH25g==|GgsEiY35U+Fb0INZ7KSUGQ==|k7dLy2L2x90ryVUirPzeT6oeMGXhUt43XdLzpGVvntE=",
@@ -305,842 +176,19 @@
 					"PostalCode": "2.jPvPSDPMoZ4nvJkQSGoiRQ==|BGebqjxfsICXqejZ4DAn7Q==|jk4gzHUQllJT9/DnEb8QyUhY60WDStzrjhG/3nb2P+4=",
 					"Country": "2.hV+lHFjIwzrCPxUoIgSDkA==|dcEp0x1FWCZT2eeakXITAw==|zGL5XRaIlpBusP1BE19BfoBcKb0U/9apVDTGk84x8lI="
 				},
-				"Login": {
-					"Password": "",
-					"Totp": "",
-					"URI": "",
-					"URIs": null,
-					"Username": ""
-				},
-				"Name": "2.wjf68OX0MD94JKVin5R5pQ==|VVZczGNLYFA3mZWKipMTMw==|QXn4bDphnWGBLDZSNvlaiMAtlRiC+TecePmrNCI0gFY=",
-				"Notes": "2.3tXh+T0SpV9g2kW5pkm6aQ==|B6+WMA3U2n92fgGvOyoMBg==|rDNfPIVp8sZIDkCZcaCNDXg8rw85LYdTOI2/dwTN2W4=",
-				"SecureNote": {
-					"Type": 0
-				}
+				"Notes": "2.3tXh+T0SpV9g2kW5pkm6aQ==|B6+WMA3U2n92fgGvOyoMBg==|rDNfPIVp8sZIDkCZcaCNDXg8rw85LYdTOI2/dwTN2W4="
 			},
 			{
 				"Type": 2,
-				"FolderID": "00000000-0000-0000-0000-000000000000",
-				"OrganizationID": "00000000-0000-0000-0000-000000000000",
-				"Favorite": false,
-				"Edit": true,
 				"ID": "8f80f479-8f2c-4074-ba61-ab0e00f428d5",
-				"Attachments": null,
-				"OrganizationUseTotp": false,
-				"RevisionDate": "2019-11-23T14:48:57.4533333Z",
-				"CollectionIDs": [],
-				"Card": {
-					"CardholderName": "",
-					"Brand": "",
-					"Number": "",
-					"ExpMonth": "",
-					"ExpYear": "",
-					"Code": ""
-				},
-				"Fields": null,
-				"Identity": {
-					"Title": "",
-					"FirstName": "",
-					"MiddleName": "",
-					"LastName": "",
-					"Username": "",
-					"Company": "",
-					"SSN": "",
-					"PassportNumber": "",
-					"LicenseNumber": "",
-					"Email": "",
-					"Phone": "",
-					"Address1": "",
-					"Address2": "",
-					"Address3": "",
-					"City": "",
-					"State": "",
-					"PostalCode": "",
-					"Country": ""
-				},
-				"Login": {
-					"Password": "",
-					"Totp": "",
-					"URI": "",
-					"URIs": null,
-					"Username": ""
-				},
 				"Name": "2.8HWg+4ZwJwSCF7UtC/Xi0Q==|/ycuakOTv7PU/9F7NrYf1TBc4x0xAtv4HadtHyVYRh0=|Zrh67qVWWDS9PvTfOnMlXLX7T3Pbh/u1/PPT4JWj8RY=",
+				"Edit": true,
+				"RevisionDate": "2019-11-23T14:48:57.4533333Z",
 				"Notes": "2.5QTxiMJjl6DTkAh1HALxeQ==|KbP1GBZIrqv43vZd/H/9rzgKJbIhnhFTB1oGezLErqE=|n+Gt1hqRPBJh0Xzcm/RsLm5xvVTCVyGSY+HKiaooMiU=",
 				"SecureNote": {
 					"Type": 0
 				}
 			}
-		],
-		"Domains": {
-			"EquivalentDomains": null,
-			"GlobalEquivalentDomains": [
-				{
-					"Type": 2,
-					"Domains": [
-						"ameritrade.com",
-						"tdameritrade.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 3,
-					"Domains": [
-						"bankofamerica.com",
-						"bofa.com",
-						"mbna.com",
-						"usecfo.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 4,
-					"Domains": [
-						"sprint.com",
-						"sprintpcs.com",
-						"nextel.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 0,
-					"Domains": [
-						"youtube.com",
-						"google.com",
-						"gmail.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 1,
-					"Domains": [
-						"apple.com",
-						"icloud.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 5,
-					"Domains": [
-						"wellsfargo.com",
-						"wf.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 6,
-					"Domains": [
-						"mymerrill.com",
-						"ml.com",
-						"merrilledge.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 7,
-					"Domains": [
-						"accountonline.com",
-						"citi.com",
-						"citibank.com",
-						"citicards.com",
-						"citibankonline.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 8,
-					"Domains": [
-						"cnet.com",
-						"cnettv.com",
-						"com.com",
-						"download.com",
-						"news.com",
-						"search.com",
-						"upload.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 9,
-					"Domains": [
-						"bananarepublic.com",
-						"gap.com",
-						"oldnavy.com",
-						"piperlime.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 10,
-					"Domains": [
-						"bing.com",
-						"hotmail.com",
-						"live.com",
-						"microsoft.com",
-						"msn.com",
-						"passport.net",
-						"windows.com",
-						"microsoftonline.com",
-						"office365.com",
-						"microsoftstore.com",
-						"xbox.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 11,
-					"Domains": [
-						"ua2go.com",
-						"ual.com",
-						"united.com",
-						"unitedwifi.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 12,
-					"Domains": [
-						"overture.com",
-						"yahoo.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 13,
-					"Domains": [
-						"zonealarm.com",
-						"zonelabs.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 14,
-					"Domains": [
-						"paypal.com",
-						"paypal-search.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 15,
-					"Domains": [
-						"avon.com",
-						"youravon.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 16,
-					"Domains": [
-						"diapers.com",
-						"soap.com",
-						"wag.com",
-						"yoyo.com",
-						"beautybar.com",
-						"casa.com",
-						"afterschool.com",
-						"vine.com",
-						"bookworm.com",
-						"look.com",
-						"vinemarket.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 17,
-					"Domains": [
-						"1800contacts.com",
-						"800contacts.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 18,
-					"Domains": [
-						"amazon.com",
-						"amazon.co.uk",
-						"amazon.ca",
-						"amazon.de",
-						"amazon.fr",
-						"amazon.es",
-						"amazon.it",
-						"amazon.com.au",
-						"amazon.co.nz",
-						"amazon.in"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 19,
-					"Domains": [
-						"cox.com",
-						"cox.net",
-						"coxbusiness.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 20,
-					"Domains": [
-						"mynortonaccount.com",
-						"norton.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 21,
-					"Domains": [
-						"verizon.com",
-						"verizon.net"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 22,
-					"Domains": [
-						"rakuten.com",
-						"buy.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 23,
-					"Domains": [
-						"siriusxm.com",
-						"sirius.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 24,
-					"Domains": [
-						"ea.com",
-						"origin.com",
-						"play4free.com",
-						"tiberiumalliance.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 25,
-					"Domains": [
-						"37signals.com",
-						"basecamp.com",
-						"basecamphq.com",
-						"highrisehq.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 26,
-					"Domains": [
-						"steampowered.com",
-						"steamcommunity.com",
-						"steamgames.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 27,
-					"Domains": [
-						"chart.io",
-						"chartio.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 28,
-					"Domains": [
-						"gotomeeting.com",
-						"citrixonline.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 29,
-					"Domains": [
-						"gogoair.com",
-						"gogoinflight.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 30,
-					"Domains": [
-						"mysql.com",
-						"oracle.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 31,
-					"Domains": [
-						"discover.com",
-						"discovercard.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 32,
-					"Domains": [
-						"dcu.org",
-						"dcu-online.org"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 33,
-					"Domains": [
-						"healthcare.gov",
-						"cms.gov"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 34,
-					"Domains": [
-						"pepco.com",
-						"pepcoholdings.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 35,
-					"Domains": [
-						"century21.com",
-						"21online.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 36,
-					"Domains": [
-						"comcast.com",
-						"comcast.net",
-						"xfinity.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 37,
-					"Domains": [
-						"cricketwireless.com",
-						"aiowireless.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 38,
-					"Domains": [
-						"mandtbank.com",
-						"mtb.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 39,
-					"Domains": [
-						"dropbox.com",
-						"getdropbox.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 40,
-					"Domains": [
-						"snapfish.com",
-						"snapfish.ca"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 41,
-					"Domains": [
-						"alibaba.com",
-						"aliexpress.com",
-						"aliyun.com",
-						"net.cn",
-						"www.net.cn"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 42,
-					"Domains": [
-						"playstation.com",
-						"sonyentertainmentnetwork.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 43,
-					"Domains": [
-						"mercadolivre.com",
-						"mercadolivre.com.br",
-						"mercadolibre.com",
-						"mercadolibre.com.ar",
-						"mercadolibre.com.mx"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 44,
-					"Domains": [
-						"zendesk.com",
-						"zopim.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 45,
-					"Domains": [
-						"autodesk.com",
-						"tinkercad.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 46,
-					"Domains": [
-						"railnation.ru",
-						"railnation.de",
-						"rail-nation.com",
-						"railnation.gr",
-						"railnation.us",
-						"trucknation.de",
-						"traviangames.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 47,
-					"Domains": [
-						"wpcu.coop",
-						"wpcuonline.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 48,
-					"Domains": [
-						"mathletics.com",
-						"mathletics.com.au",
-						"mathletics.co.uk"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 49,
-					"Domains": [
-						"discountbank.co.il",
-						"telebank.co.il"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 50,
-					"Domains": [
-						"mi.com",
-						"xiaomi.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 52,
-					"Domains": [
-						"postepay.it",
-						"poste.it"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 51,
-					"Domains": [
-						"facebook.com",
-						"messenger.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 53,
-					"Domains": [
-						"skysports.com",
-						"skybet.com",
-						"skyvegas.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 54,
-					"Domains": [
-						"disneymoviesanywhere.com",
-						"go.com",
-						"disney.com",
-						"dadt.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 55,
-					"Domains": [
-						"pokemon-gl.com",
-						"pokemon.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 56,
-					"Domains": [
-						"myuv.com",
-						"uvvu.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 58,
-					"Domains": [
-						"mdsol.com",
-						"imedidata.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 57,
-					"Domains": [
-						"bank-yahav.co.il",
-						"bankhapoalim.co.il"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 59,
-					"Domains": [
-						"sears.com",
-						"shld.net"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 60,
-					"Domains": [
-						"xiami.com",
-						"alipay.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 61,
-					"Domains": [
-						"belkin.com",
-						"seedonk.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 62,
-					"Domains": [
-						"turbotax.com",
-						"intuit.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 63,
-					"Domains": [
-						"shopify.com",
-						"myshopify.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 64,
-					"Domains": [
-						"ebay.com",
-						"ebay.de",
-						"ebay.ca",
-						"ebay.in",
-						"ebay.co.uk",
-						"ebay.com.au"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 65,
-					"Domains": [
-						"techdata.com",
-						"techdata.ch"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 66,
-					"Domains": [
-						"schwab.com",
-						"schwabplan.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 68,
-					"Domains": [
-						"tesla.com",
-						"teslamotors.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 69,
-					"Domains": [
-						"morganstanley.com",
-						"morganstanleyclientserv.com",
-						"stockplanconnect.com",
-						"ms.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 70,
-					"Domains": [
-						"taxact.com",
-						"taxactonline.com"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 71,
-					"Domains": [
-						"mediawiki.org",
-						"wikibooks.org",
-						"wikidata.org",
-						"wikimedia.org",
-						"wikinews.org",
-						"wikipedia.org",
-						"wikiquote.org",
-						"wikisource.org",
-						"wikiversity.org",
-						"wikivoyage.org",
-						"wiktionary.org"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 72,
-					"Domains": [
-						"airbnb.at",
-						"airbnb.be",
-						"airbnb.ca",
-						"airbnb.ch",
-						"airbnb.cl",
-						"airbnb.co.cr",
-						"airbnb.co.id",
-						"airbnb.co.in",
-						"airbnb.co.kr",
-						"airbnb.co.nz",
-						"airbnb.co.uk",
-						"airbnb.co.ve",
-						"airbnb.com",
-						"airbnb.com.ar",
-						"airbnb.com.au",
-						"airbnb.com.bo",
-						"airbnb.com.br",
-						"airbnb.com.bz",
-						"airbnb.com.co",
-						"airbnb.com.ec",
-						"airbnb.com.gt",
-						"airbnb.com.hk",
-						"airbnb.com.hn",
-						"airbnb.com.mt",
-						"airbnb.com.my",
-						"airbnb.com.ni",
-						"airbnb.com.pa",
-						"airbnb.com.pe",
-						"airbnb.com.py",
-						"airbnb.com.sg",
-						"airbnb.com.sv",
-						"airbnb.com.tr",
-						"airbnb.com.tw",
-						"airbnb.cz",
-						"airbnb.de",
-						"airbnb.dk",
-						"airbnb.es",
-						"airbnb.fi",
-						"airbnb.fr",
-						"airbnb.gr",
-						"airbnb.gy",
-						"airbnb.hu",
-						"airbnb.ie",
-						"airbnb.is",
-						"airbnb.it",
-						"airbnb.jp",
-						"airbnb.mx",
-						"airbnb.nl",
-						"airbnb.no",
-						"airbnb.pl",
-						"airbnb.pt",
-						"airbnb.ru",
-						"airbnb.se"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 73,
-					"Domains": [
-						"eventbrite.at",
-						"eventbrite.be",
-						"eventbrite.ca",
-						"eventbrite.ch",
-						"eventbrite.cl",
-						"eventbrite.co.id",
-						"eventbrite.co.in",
-						"eventbrite.co.kr",
-						"eventbrite.co.nz",
-						"eventbrite.co.uk",
-						"eventbrite.co.ve",
-						"eventbrite.com",
-						"eventbrite.com.au",
-						"eventbrite.com.bo",
-						"eventbrite.com.br",
-						"eventbrite.com.co",
-						"eventbrite.com.hk",
-						"eventbrite.com.hn",
-						"eventbrite.com.pe",
-						"eventbrite.com.sg",
-						"eventbrite.com.tr",
-						"eventbrite.com.tw",
-						"eventbrite.cz",
-						"eventbrite.de",
-						"eventbrite.dk",
-						"eventbrite.fi",
-						"eventbrite.fr",
-						"eventbrite.gy",
-						"eventbrite.hu",
-						"eventbrite.ie",
-						"eventbrite.is",
-						"eventbrite.it",
-						"eventbrite.jp",
-						"eventbrite.mx",
-						"eventbrite.nl",
-						"eventbrite.no",
-						"eventbrite.pl",
-						"eventbrite.pt",
-						"eventbrite.ru",
-						"eventbrite.se"
-					],
-					"Excluded": false
-				},
-				{
-					"Type": 74,
-					"Domains": [
-						"stackexchange.com",
-						"superuser.com",
-						"stackoverflow.com",
-						"serverfault.com",
-						"mathoverflow.net",
-						"askubuntu.com"
-					],
-					"Excluded": false
-				}
-			]
-		}
+		]
 	}
 }

--- a/testdata/scripts/dump.txt
+++ b/testdata/scripts/dump.txt
@@ -17,9 +17,7 @@ cmp stdout stdout.golden
 -- stdout.golden --
 # Logins:
 name	uri	username	password
+Organization Test Credential	Test	1234
 login1	domain1.com	username1	password1
 justpassword	singlepassword
 allfields	url1	username	password
-john's card
-John's Identity
-Some secure note


### PR DESCRIPTION
Adds basic support for organizations. I tested only dump so far, but also implemented support for serve. Fixes #19 

### Technical details
Each user profile has a private key. It is pkcs#8 encoded RSA. This key is encrypted with the accounts symmetric master key. The organizations stored in Profile.Organizations each have an encrypted symmetric master key, with which the organization ciphers are encrypted (or technically an encryption key as the first 32 bytes, and a mac key as the last 32 bytes).

The procedure is now as follows: With the master key, decrypt the private key. Save the private key in the secretCache. For each organization, decrypt the encrypted organization symmetric master key using the private key, and store them in a map in the secretCache.

To decrypt a cipher, the code then has to retreive the keys from the secret cache.

I used decryptWith instead of secrets.decrypt, since the cipherstring does not know it is encrypted with the organizations key, and thus secrets.decrypt uses the user's own keys.

In bitwarden's TypeScript clients, they actually pass the orgId in the decrypt call, which is how they know which keys to retrieve, should we do that here too?
https://github.com/bitwarden/clients/blob/fbd0d41b518445502b7d09d15ad27c9daa44acee/libs/common/src/models/domain/enc-string.ts#L142-L161